### PR TITLE
Add basic TravisCI Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,11 @@
 /.project
 /.pydevproject
 /.settings/
+/.idea/
 /build/
 /dist/
 /__pycache__/
 /lastLogs.html
 /masternode.conf
+/venv/
+/.pytest_cache/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: python
+sudo: required
+matrix:
+  include:
+    - name: "Python 3.7.1 on Xenial Linux"
+      python: 3.7
+      dist: xenial
+      before_install: sudo apt-get install -y libusb-1.0-0-dev libudev-dev
+    - name: "Python 3.7.2 on macOS"
+      os: osx
+      osx_image: xcode10.2
+      language: shell
+      env: PATH=/Users/travis/Library/Python/3.7/bin:$PATH
+    - name: "Python 3.7.3 on Windows"
+      os: windows
+      language: shell
+      before_install: choco install python vcredist-all
+      env: PATH=/c/Python37:/c/Python37/Scripts:/c/Users/travis/AppData/Roaming/Python/Python37/Scripts:$PATH
+install:
+  - pip3 install --user -r requirements.txt || pip3 install -r requirements.txt
+  - pip3 install --user pyinstaller==3.3 || pip3 install pyinstaller==3.3
+script: pyinstaller --onefile --windowed SecurePivxMasternodeTool.spec


### PR DESCRIPTION
Adds some basic TravisCI testing to ensure PyInstaller packaging success for Linux/Mac/Windows.

Note: Had to use v3.3 of PyInstaller as v3.4 introduced a tighter restriction revolving around empty DEST's, which was causing failures under windows.