### PR TITLE
[Travis] Update windows configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,12 @@ matrix:
       osx_image: xcode10.2
       language: shell
       env: PATH=/Users/travis/Library/Python/3.7/bin:$PATH
-    - name: "Python 3.7.3 on Windows"
+    - name: "Python 3.7.4 on Windows"
       os: windows
       language: shell
       before_install: choco install python vcredist-all
       env: PATH=/c/Python37:/c/Python37/Scripts:/c/Users/travis/AppData/Roaming/Python/Python37/Scripts:$PATH
 install:
   - pip3 install --user -r requirements.txt || pip3 install -r requirements.txt
-  - pip3 install --user pyinstaller==3.3 || pip3 install pyinstaller==3.3
+  - pip3 install --user pyinstaller || pip3 install pyinstaller
 script: pyinstaller --onefile --windowed SecurePivxMasternodeTool.spec


### PR DESCRIPTION
Since the windows environment used in TravisCI has updated to Python 3.7.4, we no longer need to use version 3.3 of pyinstaller explicitly. 