### PR TITLE
[Usability] Enable HW connection directly from SweepAll dialog

### DIFF
--- a/setup.nsi
+++ b/setup.nsi
@@ -62,7 +62,7 @@ SectionEnd
 
 Section -Post
   WriteUninstaller "$INSTDIR\uninst.exe"
-  WriteRegStr HKLM "${PRODUCT_DIR_REGKEY}" "" "$INSTDIR\app\SecurePivxMasternodeTool.exe"
+  WriteRegStr HKLM "${PRODUCT_DIR_REGKEY}" "" "$INSTDIR\SecurePivxMasternodeTool.exe"
   WriteRegStr ${PRODUCT_UNINST_ROOT_KEY} "${PRODUCT_UNINST_KEY}" "DisplayName" "$(^Name)"
   WriteRegStr ${PRODUCT_UNINST_ROOT_KEY} "${PRODUCT_UNINST_KEY}" "UninstallString" "$INSTDIR\uninst.exe"
   WriteRegStr ${PRODUCT_UNINST_ROOT_KEY} "${PRODUCT_UNINST_KEY}" "DisplayIcon" "$INSTDIR\SecurePivxMasternodeTool.exe"

--- a/src/qt/dlg_sweepAll.py
+++ b/src/qt/dlg_sweepAll.py
@@ -13,7 +13,7 @@ from PyQt5.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QPushButton, QTab
 
 from constants import MINIMUM_FEE
 from misc import printDbg, getCallerName, getFunctionName, printException, persistCacheSetting, \
-    myPopUp_sb, DisconnectedException
+    myPopUp_sb, DisconnectedException, myPopUp
 from pivx_parser import ParseTx
 from threads import ThreadFuns
 from utils import checkPivxAddr
@@ -138,14 +138,17 @@ class SweepAll_dlg(QDialog):
 
 
     def onButtonSend(self):
+        # Check HW connection
+        while self.main_tab.caller.hwStatus != 2:
+            mess = "HW device not connected. Try to connect?"
+            ans = myPopUp(self.main_tab.caller, QMessageBox.Question, 'PET4L - hw check', mess)
+            if ans == QMessageBox.No:
+                return
+            # re connect
+            self.main_tab.caller.onCheckHw()
         try:
             self.dest_addr = self.ui.edt_destination.text().strip()
             self.currFee = self.ui.feeLine.value() * 1e8
-
-             # Check RPC & HW device
-            if not self.main_tab.caller.rpcConnected or self.main_tab.caller.hwStatus != 2:
-                myPopUp_sb(self.main_tab.caller, "crit", 'SPMT - hw/rpc device check', "Connect to RPC server and HW device first")
-                return None
 
             # Check destination Address
             if not checkPivxAddr(self.dest_addr, self.main_tab.caller.isTestnetRPC):

--- a/src/spmtApp.py
+++ b/src/spmtApp.py
@@ -154,9 +154,6 @@ class App(QMainWindow):
 
 
     def closeEvent(self, *args, **kwargs):
-        # Restore output stream
-        sys.stdout = sys.__stdout__
-
         # Terminate the running threads.
         # Set the shutdown flag on each thread to trigger a clean shutdown of each thread.
         self.mainWindow.myRpcWd.shutdown_flag.set()

--- a/src/tabMain.py
+++ b/src/tabMain.py
@@ -240,8 +240,8 @@ class TabMain():
 
 
     def onSweepAllRewards(self):
-        if not self.caller.rpcConnected or self.caller.hwStatus != 2:
-            myPopUp_sb(self.caller, "crit", 'SPMT - hw/rpc device check', "Connect to RPC server and HW device first")
+        if not self.caller.rpcConnected:
+            myPopUp_sb(self.caller, "crit", 'SPMT - rpc check', "Connect to wallet / RPC server first")
             return None
         try:
             self.sweepAllDlg.showDialog()

--- a/src/tabRewards.py
+++ b/src/tabRewards.py
@@ -215,12 +215,9 @@ class TabRewards():
                         # double check that the rpc connection is still active, else reconnect
                         if self.caller.rpcClient is None:
                             self.caller.updateRPCstatus(None)
-                        try:
-                            rawtx = self.caller.rpcClient.getRawTransaction(utxo['txid'])
-                        except Exception as e:
-                            printError(getCallerName(), getFunctionName(),
-                                       "Unable to get raw TX with hash=%s from RPC server: %s" % (
-                                           utxo['txid'], str(e)))
+                        rawtx = self.caller.rpcClient.getRawTransaction(utxo['txid'])
+                        if rawtx is None:
+                            printDbg("Unable to get raw TX with hash=%s from RPC server." % utxo['txid'])
                             # Don't save UTXO if raw TX is unavailable
                             continue
                     else:

--- a/src/tabRewards.py
+++ b/src/tabRewards.py
@@ -450,6 +450,7 @@ class TabRewards():
                         txid = self.caller.rpcClient.sendRawTransaction(tx_hex, self.useSwiftX())
                         if txid is None:
                             raise Exception("Unable to send TX - connection to RPC server lost.")
+                        printDbg("Transaction sent. ID: %s" % txid)
                         mess2_text = "<p>Transaction successfully sent.</p>"
                         mess2 = QMessageBox(QMessageBox.Information, 'transaction Sent', mess2_text)
                         mess2.setDetailedText(txid)

--- a/src/utils.py
+++ b/src/utils.py
@@ -148,12 +148,12 @@ def extract_pkh_from_locking_script(script):
             else:
                 raise Exception('Non-standard public key hash length (should be 20)')
 
-        elif len(script) == 35:
-            scriptlen = read_varint(script, 0)[0]
-            if scriptlen in [32, 33]:
-                return bin_hash160(script[1:1 + scriptlen])
-            else:
-                raise Exception('Non-standard public key length (should be 32 or 33)')
+    elif len(script) == 35:
+        scriptlen = read_varint(script, 0)[0]
+        if scriptlen in [32, 33]:
+            return bin_hash160(script[1:1 + scriptlen])
+        else:
+            raise Exception('Non-standard public key length (should be 32 or 33)')
     raise Exception('Non-standard locking script type (should be P2PKH or P2PK). len is %d' % len(script))
 
 


### PR DESCRIPTION
Follows a feature request received.
This allows the user to open the SweepAll dialog and load the rewards even when
the HW device is not connected, for accounting purposes.

The connection with the device is now checked after clicking 'Send' and the user has the option to reconnect directly (without having to close and reopen the dialog).