### PR TITLE
[Ledger] Fix HW connection for new app version

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     defaults:
       run:
         shell: bash
@@ -45,7 +45,7 @@ jobs:
       matrix:
         config:
           - name: Linux
-            os: ubuntu-16.04
+            os: ubuntu-18.04
             cachepath: ~/.cache/pip
             packages: libusb-1.0-0-dev libudev-dev
 

--- a/src/ledgerClient.py
+++ b/src/ledgerClient.py
@@ -50,6 +50,15 @@ def process_ledger_exceptions(func):
     return process_ledger_exceptions_int
 
 
+class BTchip(btchip):
+    def getJCExtendedFeatures(self):
+        # Workaround for the incompatibility with the btchip client library introduced in the Ledger PIVX app v2.0.4:
+        # mask the original call to 'getJCExtendedFeatures', which destabilizes communication with the device
+        # by sending the BTCHIP_INS_EXT_CACHE_GET_FEATURES command
+        result = {'proprietaryApi': True}
+        return result
+
+
 class LedgerApi(QObject):
     # signal: sig1 (thread) is done - emitted by signMessageFinish
     sig1done = pyqtSignal(str)
@@ -86,7 +95,7 @@ class LedgerApi(QObject):
             self.status = 0
             self.dongle = getDongle(False)
             printOK('Ledger Nano drivers found')
-            self.chip = btchip(self.dongle)
+            self.chip = BTchip(self.dongle)
             printDbg("Ledger Initialized")
             self.status = 1
             ver = self.chip.getFirmwareVersion()


### PR DESCRIPTION
Ledger's PIVX app starting from v2.0.4 introduced a bug that prevents the HW connection from completing.

This fixes the issue by overloading an internal call.