### PR TITLE
[GUI] Disable MyVotes column

### DIFF
--- a/src/qt/gui_tabGovernance.py
+++ b/src/qt/gui_tabGovernance.py
@@ -59,7 +59,7 @@ class TabGovernance_gui(QWidget):
         self.proposalBox.setSelectionMode(QAbstractItemView.MultiSelection)
         self.proposalBox.setSelectionBehavior(QAbstractItemView.SelectRows)
         self.proposalBox.setShowGrid(True)
-        self.proposalBox.setColumnCount(8)
+        self.proposalBox.setColumnCount(7)
         self.proposalBox.setRowCount(0)
         self.proposalBox.horizontalHeader().setSectionResizeMode(0, QHeaderView.Stretch)
         self.proposalBox.setSortingEnabled(True)
@@ -70,8 +70,8 @@ class TabGovernance_gui(QWidget):
         self.proposalBox.setColumnWidth(3, 100)
         self.proposalBox.setColumnWidth(4, 100)
         self.proposalBox.setColumnWidth(5, 150)
-        self.proposalBox.setColumnWidth(6, 120)
-        self.proposalBox.setColumnWidth(7, 50)
+        #self.proposalBox.setColumnWidth(6, 120)
+        self.proposalBox.setColumnWidth(6, 50)
         layout.addWidget(self.proposalBox)
 
         #  -- ROW 3
@@ -179,17 +179,17 @@ class TabGovernance_gui(QWidget):
         item.setToolTip("Network Votes: YEAS/ABSTAINS/NAYS")
         self.proposalBox.setHorizontalHeaderItem(5, item)
 
-        item = QTableWidgetItem()
-        item.setTextAlignment(Qt.AlignCenter)
-        item.setText("My Votes")
-        item.setToolTip("My Votes: YEAS/ABSTAINS/NAYS")
-        self.proposalBox.setHorizontalHeaderItem(6, item)
+        #item = QTableWidgetItem()
+        #item.setTextAlignment(Qt.AlignCenter)
+        #item.setText("My Votes")
+        #item.setToolTip("My Votes: YEAS/ABSTAINS/NAYS")
+        #self.proposalBox.setHorizontalHeaderItem(6, item)
 
         item = QTableWidgetItem()
         item.setTextAlignment(Qt.AlignCenter)
         item.setText("Details")
         item.setToolTip("Check Proposal Details")
-        self.proposalBox.setHorizontalHeaderItem(7, item)
+        self.proposalBox.setHorizontalHeaderItem(6, item)
 
     def loadIcons(self):
         self.refresh_icon = QIcon(os.path.join(self.caller.imgDir, 'icon_refresh.png'))

--- a/src/tabGovernance.py
+++ b/src/tabGovernance.py
@@ -156,12 +156,12 @@ class TabGovernance():
             self.ui.proposalBox.setItem(row, 5, votes)
 
             # 6 - myVotes
-            myYeas, myAbstains, myNays = self.coutMyVotes(prop)
-            my_votes = "%d / %d / %d" % (myYeas, myAbstains, myNays)
-            self.ui.proposalBox.setItem(row, 6, item(my_votes))
+            #myYeas, myAbstains, myNays = self.coutMyVotes(prop)
+            #my_votes = "%d / %d / %d" % (myYeas, myAbstains, myNays)
+            #self.ui.proposalBox.setItem(row, 6, item(my_votes))
 
             # 7 - details Button
-            self.ui.proposalBox.setCellWidget(row, 7, itemButton(prop, 1))
+            self.ui.proposalBox.setCellWidget(row, 6, itemButton(prop, 1))
 
             # hide row if toggleExpiring_btn set
             if prop.RemainingPayCount == 0 and self.ui.toggleExpiring_btn.text() == "Show Expiring":
@@ -195,7 +195,7 @@ class TabGovernance():
         # persist masternode number
         self.caller.parent.cache['MN_count'] = persistCacheSetting('cache_MNcount', mnCount)
 
-        self.updateMyVotes()
+        #self.updateMyVotes()
         printDbg("--# PROPOSALS table updated")
         self.proposalsLoaded = True
         self.caller.sig_ProposalsLoaded.emit()
@@ -390,4 +390,4 @@ class TabGovernance():
         # refresh my votes on proposals
         self.ui.selectedPropLabel.setText("<em><b>0</b> proposals selected")
         self.ui.resetStatusLabel()
-        ThreadFuns.runInThread(self.updateMyVotes_thread, (), self.displayProposals)
+        #ThreadFuns.runInThread(self.updateMyVotes_thread, (), self.displayProposals)


### PR DESCRIPTION
The functionality of fetching the vote count for configured MNs in SPMT has not worked properly for quite some time. Further, an errant proposal name causes the process to break here.

Disable the MyVotes process and hide the UI column for now.