### PR TITLE
[GA] Bump to newer workers

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -10,19 +10,20 @@ jobs:
         shell: bash
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Initialize Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.7
 
       - name: Install Dependencies
         run: |
-          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install --upgrade wheel
           pip install -r requirements.txt
+          pip install importlib-metadata==4.13.0
           pip install flake8==3.8.4
           pip install mypy==0.781
           pip install vulture==2.3
@@ -59,13 +60,13 @@ jobs:
 
     steps:
       - name: Get Source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Python 3.7
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.7
       - name: Setup pip cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ matrix.config.cachepath }}
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
@@ -77,7 +78,7 @@ jobs:
             sudo apt-get update
             sudo apt-get install --no-install-recommends --no-upgrade -qq ${{ matrix.config.packages }}
           fi
-          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install --upgrade wheel
           pip install -r requirements.txt
           pip install pyinstaller
       - name: Build

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     defaults:
       run:
         shell: bash
@@ -45,12 +45,12 @@ jobs:
       matrix:
         config:
           - name: Linux
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             cachepath: ~/.cache/pip
             packages: libusb-1.0-0-dev libudev-dev
 
           - name: macOS
-            os: macos-10.15
+            os: macos-11
             cachepath: ~/Library/Caches/pip
 
           - name: Windows


### PR DESCRIPTION
Ubuntu 18.04 workers are deprecated and will be fully unsupported in April 2023.
macOS 10.15 workers are deprecated and will be fully unsupported in December 2022.