### PR TITLE
[GUI] TorV3 Support

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -176,12 +176,13 @@ def ipmap(ip, port):
     try:
         ipv6map = ''
 
-        if len(ip) > 6 and ip.endswith('.onion'):
-            pchOnionCat = bytearray([0xFD, 0x87, 0xD8, 0x7E, 0xEB, 0x43])
+        if len(ip) == 62 and ip.endswith('.onion'):
+            vchOnionPrefix = bytes([0x04, 32])
             vchAddr = base64.b32decode(ip[0:-6], True)
-            if len(vchAddr) != 16 - len(pchOnionCat):
-                raise Exception('Invalid onion %s' % str(ip))
-            return pchOnionCat.hex() + vchAddr.hex() + int(port).to_bytes(2, byteorder='big').hex()
+            vchAddrBytes = vchOnionPrefix + vchAddr[:32]
+            if len(vchAddr) != 35 and vchAddr[-1] != b'\x03':
+                raise Exception('Invalid TorV3 address %s' % str(ip))
+            return vchAddrBytes.hex() + int(port).to_bytes(2, byteorder='big').hex()
 
         ipAddr = ip_address(ip)
 


### PR DESCRIPTION
This pull request creates TorV3 Address parsing functionality. TorV2 was depreciated nearly 2 years ago and should not have access to the Tor network anymore. Therefore we need to support TorV3 for users now in SPMT. 

Problems still arise, because this work relies on the work done in this PR as well: https://github.com/PIVX-Project/PIVX/pull/2873

SPMT uses `decodemasternodebroadcast` and `relaymasternodebroadcast` which get updated in the above PR.

We have removed TorV2 checks entirely because they should not be functional.

Successful Broadcast Creation:
![image](https://github.com/PIVX-Project/PIVX-SPMT/assets/45834289/3ad52805-e59a-409d-bf1c-bea74584e8aa)
Successfully Started:
![image](https://github.com/PIVX-Project/PIVX-SPMT/assets/45834289/ddb07b03-80d9-41b3-814e-5c97ee6d3981)
Verification on daemon:
```pivx-cli -rpcconnect=127.0.0.2 getmasternodestatus
{
  "txhash": "07b9b7beeb74c0bcef1d004c83b1ff741f776f2e4a6b6e8cf78ce7b8970d7b53",
  "outputidx": 0,
  "netaddr": "ovt6bxnzdj6afty22ccayzkuxnhhfuqjbn5gubmps4velhsxbmct6qyd.onion:51472",
  "addr": "DRndVQTocPwbPGRUzCUeFhXu36NerLsBHR",
  "status": 4,
  "message": "Masternode successfully started"
}
```

Key things to TorV3 address parsing:
Network ID as a PREFIX is 0x04 in determining its a TORV3 address through network messages
Version is always '\x03' which is the 'd' at the end of the .onion address (last char before .onion)
Length is always 62 characters and 35 bytes length.