### PR TITLE
Bump Python version to 3.10

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Initialize Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.7
+          python-version: '3.10'
 
       - name: Install Dependencies
         run: |
@@ -61,10 +61,10 @@ jobs:
     steps:
       - name: Get Source
         uses: actions/checkout@v4
-      - name: Setup Python 3.7
+      - name: Setup Python 3.10
         uses: actions/setup-python@v5
         with:
-          python-version: 3.7
+          python-version: '3.10'
       - name: Setup pip cache
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
This will update our GitHub actions to use Python 3.10 instead of the current version 3.7.

Python EOL's are intended 5 years after their release date. Python 3.7 was released in June 2018. Therefore the EOL was June 2023. As it is now 2024, we are bumping to Python 3.10 for wider compatibility and support.

Note: Windows failure is from PyQt lib which will be/is updated in #60 