### PR TITLE
[Build] Add distribution packaging functionality

### DIFF
--- a/contrib/macdeploy/appdmg.json.in
+++ b/contrib/macdeploy/appdmg.json.in
@@ -1,0 +1,13 @@
+{
+  "title": "SPMT %version%",
+  "icon": "../img/spmt.icns",
+  "icon-size": 96,
+  "background": "background.tiff",
+  "contents": [
+    { "x": 370, "y": 156, "type": "link", "path": "/Applications" },
+    { "x": 128, "y": 156, "type": "file", "path": "SecurePivxMasternodeTool.app" }
+  ],
+  "code-sign": {
+    "signing-identity": "%signer%"
+  }
+}

--- a/contrib/macdeploy/background.svg
+++ b/contrib/macdeploy/background.svg
@@ -1,0 +1,34 @@
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 20010904//EN"
+ "http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd">
+<svg version="1.0" xmlns="http://www.w3.org/2000/svg" width="1000pt" height="640pt" viewBox="0 0 1000 640" preserveAspectRatio="xMidYMid meet">
+	<!-- kate: space-indent off;
+	Copyright (c) 2015 The Bitcoin Core developers
+	Distributed under the MIT software license, see the accompanying
+	file COPYING or http://www.opensource.org/licenses/mit-license.php.
+	-->
+	<style type="text/css"><![CDATA[
+		text {
+			font-family: "Tuffy";
+			font-size: 86px;
+			fill: gray;
+			text-anchor: middle;
+		}
+	]]></style>
+	<defs>
+		<linearGradient id="gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+			<stop offset="0%" style="stop-color:rgb(239,239,239);stop-opacity:1" />
+			<stop offset="33%" style="stop-color:rgb(239,239,239);stop-opacity:1" />
+			<stop offset="80%" style="stop-color:rgb(205,205,205);stop-opacity:1" />
+			<stop offset="100%" style="stop-color:rgb(204,204,204);stop-opacity:1" />
+		</linearGradient>
+	</defs>
+	<rect width="1000" height="640" style="fill:url(#gradient);stroke-width:0" />
+	<g transform="translate(500,0) scale(1, 1)">
+		<text x="0" y="114">PACKAGE_NAME</text>
+	</g>
+	<g transform="translate(0.000000,640.000000) scale(0.100000,-0.100000)"
+	fill="#000000" stroke="none">
+		<path d="M4995 3705 c-24 -23 -25 -29 -25 -165 l0 -140 -306 0 -306 0 -29 -29 c-29 -29 -29 -31 -29 -141 0 -110 0 -112 29 -141 l29 -29 306 0 306 0 0 -140 c0 -136 1 -142 25 -165 16 -17 35 -25 57 -25 29 0 72 32 306 226 180 149 274 233 278 250 13 53 -2 70 -278 299 -235 194 -277 225 -306 225 -22 0 -41 -8 -57 -25z" fixlter="url(#glow)"/>
+	</g>
+</svg>

--- a/contrib/macdeploy/entitlements.plist
+++ b/contrib/macdeploy/entitlements.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<true/>
+	<key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+	<key>com.apple.security.automation.apple-events</key>
+	<true/>
+	<key>com.apple.security.cs.allow-jit</key>
+    <true/>
+	<key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
+    <key>com.apple.security.device.camera</key>
+    <true/>
+</dict>
+</plist>


### PR DESCRIPTION
Adds code to the `.spec` file used to create the distribution binaries. Requires `pyinstaller`. The macOS binaries further require the node.js `appdmg` package for `.dmg` creation, and a valid Apple issued developer ID certificate for code signing.