### PR TITLE
[Build] Update build reqs

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -21,7 +21,9 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          pip install wheel==0.38.4
+          pip install pip==24.0
+          pip install wheel==0.35.0
+          pip install setuptools==53.0.0
           pip install -r requirements.txt
           pip install importlib-metadata==4.13.0
           pip install flake8==3.8.4
@@ -51,7 +53,7 @@ jobs:
             packages: libusb-1.0-0-dev libudev-dev
 
           - name: macOS
-            os: macos-11
+            os: macos-12
             cachepath: ~/Library/Caches/pip
 
           - name: Windows
@@ -78,7 +80,13 @@ jobs:
             sudo apt-get update
             sudo apt-get install --no-install-recommends --no-upgrade -qq ${{ matrix.config.packages }}
           fi
-          pip install wheel==0.38.4
+          if [[ ${{ matrix.config.os }} = windows* ]]; then
+            python.exe -m pip install pip==24.0
+          else
+            pip install pip==24.0
+          fi
+          pip install wheel==0.35.0
+          pip install setuptools==53.0.0
           pip install -r requirements.txt
           pip install pyinstaller
       - name: Build

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
+wheel==0.35.0
+setuptools==53.0.0
 python-bitcoinrpc==1.0
 bitcoin==1.1.42
 btchip-python==0.1.27
-trezor==0.11.1
+trezor==0.11.5
 PyQt5>=5.15.10
 requests==2.32.2
 simplejson==3.19.2
 ecdsa==0.19.0
-wheel==0.38.1
-setuptools==69.5.1


### PR DESCRIPTION
Some more package version incompatibilities cropped up due to btchip-python using invalid metadata.

The following packages are now pinned to compatible versions that don't rely on any package caching:

- pip == 24.0
- setuptools == 53.0.0
- wheel == 0.35.0

Additionally, trezor has been bumped to 0.11.5, the earliest version that dropped the need to use the now defunct pyblake2 package.