### PR TITLE
Refactored SSL Handling

### DIFF
--- a/src/blockbookClient.py
+++ b/src/blockbookClient.py
@@ -5,6 +5,7 @@
 # file LICENSE.txt or http://www.opensource.org/licenses/mit-license.php.
 
 import requests
+import certifi
 
 from misc import getCallerName, getFunctionName, printException
 
@@ -45,7 +46,7 @@ class BlockBookClient:
         url = f"{self.url}/api/{method}"
         if param != "":
             url += "/{param}"
-        resp = requests.get(url, data={}, verify=True)
+        resp = requests.get(url, data={}, verify=certifi.where())
         if resp.status_code == 200:
             data = resp.json()
             return data

--- a/src/cryptoIDClient.py
+++ b/src/cryptoIDClient.py
@@ -6,6 +6,7 @@
 
 from random import choice
 import requests
+import certifi
 
 from misc import getCallerName, getFunctionName, printException
 
@@ -51,7 +52,7 @@ class CryptoIDClient:
     def checkResponse(self, parameters):
         key = choice(api_keys)
         parameters['key'] = key
-        resp = requests.get(self.url, params=parameters)
+        resp = requests.get(self.url, params=parameters, verify=certifi.where())
         if resp.status_code == 200:
             data = resp.json()
             return data

--- a/src/mainWindow.py
+++ b/src/mainWindow.py
@@ -522,7 +522,10 @@ class MainWindow(QWidget):
             return
 
         rpcResponseTime = None
-        if r_time1 is not None and r_time2 != 0:
+        if r_time1 is None:
+            r_time1 = 0.0
+        if r_time2 is None:
+            r_time2 = 0.0
             rpcResponseTime = round((r_time1 + r_time2) / 2, 3)
 
         # Do not update status if the user has selected a different server since the start of updateRPCStatus()

--- a/src/misc.py
+++ b/src/misc.py
@@ -191,8 +191,9 @@ def getFunctionName(inDecorator=False):
 
 def getRemoteSPMTversion():
     import requests
+    import certifi
     try:
-        resp = requests.get("https://raw.githubusercontent.com/PIVX-Project/PIVX-SPMT/master/src/version.txt")
+        resp = requests.get("https://raw.githubusercontent.com/PIVX-Project/PIVX-SPMT/master/src/version.txt", verify=certifi.where())
         if resp.status_code == 200:
             data = resp.json()
             return data['number']

--- a/src/rpcClient.py
+++ b/src/rpcClient.py
@@ -9,6 +9,7 @@ from bitcoinrpc.authproxy import AuthServiceProxy
 import http.client as httplib
 import ssl
 import threading
+import certifi
 
 from constants import DEFAULT_PROTOCOL_VERSION, MINIMUM_FEE
 from misc import getCallerName, getFunctionName, printException, printDbg, now, timeThis
@@ -50,7 +51,9 @@ class RpcClient:
 
         host, port = rpc_host.split(":")
         if rpc_protocol == "https":
-            self.httpConnection = httplib.HTTPSConnection(host, port, timeout=20, context=ssl.create_default_context())
+            ssl_context = ssl.create_default_context()
+            ssl_context.load_verify_locations(cafile=certifi.where())
+            self.httpConnection = httplib.HTTPSConnection(host, port, timeout=20, context=ssl_context)
         else:
             self.httpConnection = httplib.HTTPConnection(host, port, timeout=20)
 

--- a/src/rpcClient.py
+++ b/src/rpcClient.py
@@ -5,11 +5,7 @@
 # file LICENSE.txt or http://www.opensource.org/licenses/mit-license.php.
 
 from bitcoinrpc.authproxy import AuthServiceProxy
-
-import http.client as httplib
-import ssl
 import threading
-import certifi
 
 from constants import DEFAULT_PROTOCOL_VERSION, MINIMUM_FEE
 from misc import getCallerName, getFunctionName, printException, printDbg, now, timeThis


### PR DESCRIPTION
Users have been reporting issues with their SSL certificates failing to verify. After research we have found that some packages are handled differently now with 3.10 vs 3.9 python versions. This makes a need for how we were handling things before for users to install an extra python package which is not suitable for them. Which is also why it was not caught in testing as we have these packages installed already in our environments.

We are now importing the certifi package and using that to grab the SSL root certificate paths to pass approrpiately to verify against root certs. 

I have changed the way we are handling the HTTP/HTTPS connections for the RPC client because it is also handled in the bitcoin json rpc library we are using causing some confusion with our use of `self.httpConnection` and then AuthServiceProxy having similar check in its init function.

Lastly, when testing after this I had some crashing from the response time calculation for trying to add a 'None' type by a float value, and so incase of 'None' we now set it to a default float value of 0.0 to resolve this.