### PR TITLE
[CI] Expand github actions coverage

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -51,7 +51,7 @@ jobs:
             cachepath: ~/Library/Caches/pip
 
           - name: Windows
-            os: windows-2019
+            os: windows-2022
             cachepath: ~\AppData\Local\pip\Cache
 
     steps:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -50,6 +50,10 @@ jobs:
             os: macos-13
             cachepath: ~/Library/Caches/pip
 
+          - name: macOS-arm
+            os: macos-14
+            cachepath: ~/Library/Caches/pip
+
           - name: Windows
             os: windows-2022
             cachepath: ~\AppData\Local\pip\Cache

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -49,10 +49,12 @@ jobs:
           - name: macOS
             os: macos-13
             cachepath: ~/Library/Caches/pip
+            packages: imagemagick librsvg
 
           - name: macOS-arm
             os: macos-14
             cachepath: ~/Library/Caches/pip
+            packages: imagemagick librsvg
 
           - name: Windows
             os: windows-2022
@@ -65,6 +67,10 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.10'
+      - name: Setup node.js 22
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
       - name: Setup pip cache
         uses: actions/cache@v4
         with:
@@ -77,6 +83,10 @@ jobs:
           if [[ ${{ matrix.config.os }} = ubuntu* ]]; then
             sudo apt-get update
             sudo apt-get install --no-install-recommends --no-upgrade -qq ${{ matrix.config.packages }}
+          fi
+          if [[ ${{ matrix.config.os }} = macos* ]]; then
+            npm install -g --no-fund appdmg
+            brew install ${{ matrix.config.packages }}
           fi
           pip install -r requirements.txt
       - name: Build


### PR DESCRIPTION
- Updates the windows runner to server 2022 as server 2019 has been removed
- Adds an arm-based macOS runner
- Adds macOS `.dmg` installer creation