### PR TITLE
[Bug] Fix SSL connections for macOS

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,16 +1,17 @@
 wheel==0.45.1
-setuptools==75.8.0
+setuptools==78.1.1
+certifi
 python-bitcoinrpc==1.0
 bitcoin==1.1.42
 trezor==0.11.5
 PyQt5>=5.15.10
-requests==2.32.2
+requests==2.32.5
 simplejson==3.19.2
 ecdsa==0.19.0
 importlib-metadata==4.13.0
 flake8==3.8.4
 vulture==2.3
-pyinstaller==6.12.0
+pyinstaller==6.16.0
 # btchip-python 0.1.32 with a patch to fix a malformed dependency
 # See https://github.com/LedgerHQ/btchip-python/pull/54
 https://github.com/PIVX-Project/btchip-python/archive/e13eab8b0e665bdc23ac4b3890d2a5742303c421.tar.gz

--- a/src/blockbookClient.py
+++ b/src/blockbookClient.py
@@ -5,6 +5,7 @@
 # file LICENSE.txt or http://www.opensource.org/licenses/mit-license.php.
 
 import requests
+import certifi
 
 from misc import getCallerName, getFunctionName, printException
 
@@ -45,7 +46,7 @@ class BlockBookClient:
         url = f"{self.url}/api/{method}"
         if param != "":
             url += "/{param}"
-        resp = requests.get(url, data={}, verify=True)
+        resp = requests.get(url, data={}, verify=certifi.where())
         if resp.status_code == 200:
             data = resp.json()
             return data

--- a/src/cryptoIDClient.py
+++ b/src/cryptoIDClient.py
@@ -6,6 +6,7 @@
 
 from random import choice
 import requests
+import certifi
 
 from misc import getCallerName, getFunctionName, printException
 
@@ -51,7 +52,7 @@ class CryptoIDClient:
     def checkResponse(self, parameters):
         key = choice(api_keys)
         parameters['key'] = key
-        resp = requests.get(self.url, params=parameters)
+        resp = requests.get(self.url, params=parameters, verify=certifi.where())
         if resp.status_code == 200:
             data = resp.json()
             return data

--- a/src/misc.py
+++ b/src/misc.py
@@ -191,8 +191,9 @@ def getFunctionName(inDecorator=False):
 
 def getRemoteSPMTversion():
     import requests
+    import certifi
     try:
-        resp = requests.get("https://raw.githubusercontent.com/PIVX-Project/PIVX-SPMT/master/src/version.txt")
+        resp = requests.get("https://raw.githubusercontent.com/PIVX-Project/PIVX-SPMT/master/src/version.txt", verify=certifi.where())
         if resp.status_code == 200:
             data = resp.json()
             return data['number']

--- a/src/rpcClient.py
+++ b/src/rpcClient.py
@@ -9,6 +9,7 @@ from bitcoinrpc.authproxy import AuthServiceProxy
 import http.client as httplib
 import ssl
 import threading
+import certifi
 
 from constants import DEFAULT_PROTOCOL_VERSION, MINIMUM_FEE
 from misc import getCallerName, getFunctionName, printException, printDbg, now, timeThis
@@ -50,7 +51,9 @@ class RpcClient:
 
         host, port = rpc_host.split(":")
         if rpc_protocol == "https":
-            self.httpConnection = httplib.HTTPSConnection(host, port, timeout=20, context=ssl.create_default_context())
+            ssl_context = ssl.create_default_context()
+            ssl_context.load_verify_locations(cafile=certifi.where())
+            self.httpConnection = httplib.HTTPSConnection(host, port, timeout=20, context=ssl_context)
         else:
             self.httpConnection = httplib.HTTPConnection(host, port, timeout=20)
 


### PR DESCRIPTION
macOS was inconsistently using a mix of (old) system + certifi SSL certificates, leading to RPC endpoint connection attempts resulting in invalid SSL certificate errors.

This unifies all https connections to use certifi, which is provided at distribution time to be the latest available version, and disregard any potential stale system certificates.

Replaces #73