### PR TITLE
Fix RPC Status Call Handling

### DIFF
--- a/src/mainWindow.py
+++ b/src/mainWindow.py
@@ -440,10 +440,10 @@ class MainWindow(QWidget):
             self.header.lastPingBox.setHidden(True)
         else:
             self.header.lastPingBox.setHidden(False)
-            if self.rpcResponseTime > 2:
+            if self.rpcResponseTime is not None and self.rpcResponseTime > 2:
                 color = "red"
                 self.header.lastPingIcon.setPixmap(self.connRed_icon)
-            elif self.rpcResponseTime > 1:
+            elif self.rpcResponseTime is not None and self.rpcResponseTime > 1:
                 color = "orange"
                 self.header.lastPingIcon.setPixmap(self.connOrange_icon)
             else:


### PR DESCRIPTION
This PR fixes an issue where the RPC status call is not handled correctly,
which can cause crashing.

The crashing is random and especially present when using a local wallet 
as the RPC server.

The change is minimal (two lines), clear and correct on visual inspection, and 
scoped to the RPC status logic only. No functional behavior outside of 
the status call is affected.

Testing was done under Windows using a local-wallet RPC server.